### PR TITLE
Add KMS keys to iam role

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ pre-commit install --install-hooks
 | <a name="input_ecs_task_mem"></a> [ecs\_task\_mem](#input\_ecs\_task\_mem) | n/a | `number` | `2048` | no |
 | <a name="input_glue_crawler_exclusions"></a> [glue\_crawler\_exclusions](#input\_glue\_crawler\_exclusions) | Glue crawler exclusions. Check rules here: <https://docs.aws.amazon.com/glue/latest/dg/define-crawler.html#crawler-source-type> | `list(string)` | `[]` | no |
 | <a name="input_image_sha"></a> [image\_sha](#input\_image\_sha) | The SHA256 of the image to use in the task. Not an image tag. | `string` | n/a | yes |
+| <a name="input_keys"></a> [keys](#input\_keys) | The ARNs of the AWS KMS keys the policy is allowed to use.  Use ["*"] to allow all keys. | `list(string)` | `[]` | no |
 | <a name="input_logging_bucket"></a> [logging\_bucket](#input\_logging\_bucket) | The AWS S3 logging bucket | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The namespace for the module | `string` | `"s3-data-to-parquet"` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The schedule to run the task on in AWS cron format. | `string` | `"cron(30 * * * ? *)"` | no |

--- a/glue_iam.tf
+++ b/glue_iam.tf
@@ -35,6 +35,18 @@ data "aws_iam_policy_document" "glue_policy_document" {
       "${module.parquet_logs.arn}/*",
     ])
   }
+
+  statement {
+    sid = "KMSAccess"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey"
+    ]
+    effect    = length(var.keys) > 0 ? "Allow" : "Deny"
+    resources = length(var.keys) > 0 ? var.keys : ["*"]
+  }
+
 }
 
 resource "aws_iam_policy" "glue_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -88,3 +88,9 @@ variable "glue_crawler_exclusions" {
   description = "Glue crawler exclusions. Check rules here: <https://docs.aws.amazon.com/glue/latest/dg/define-crawler.html#crawler-source-type>"
   default     = []
 }
+
+variable "keys" {
+  type        = list(string)
+  description = "The ARNs of the AWS KMS keys the policy is allowed to use.  Use [\"*\"] to allow all keys."
+  default     = []
+}


### PR DESCRIPTION
This adds the ability for the module to use a global kms key for glue encryption.